### PR TITLE
fix percent damage fudging

### DIFF
--- a/addons/sourcemod/scripting/l4d_tank_damage_announce.sp
+++ b/addons/sourcemod/scripting/l4d_tank_damage_announce.sp
@@ -266,6 +266,7 @@ PrintTankDamage()
                                 percent_adjustment = 0;
                         }
                 }
+                last_percent = percent_damage;
                 PrintToChatAll("\x05%4d\x01 [\x04%d%%\x01]: \x03%N\x01", damage, percent_damage, client);
         }
 }


### PR DESCRIPTION
last_percent should be set to percent_damage at the end of each iteration to make the check for adjusted_percent_damage <= last_percent work as intended